### PR TITLE
change asana JSON to prevent notes with HTML tags from causing errors

### DIFF
--- a/asana.js
+++ b/asana.js
@@ -27,7 +27,7 @@ async function createTask(name, notes) {
     let body = {
         "data": {
             "name": name,
-            "html_notes": notes,
+            "notes": notes,
             "projects": asanaProjectsArray, // needs to be string array
             "completed": false,
         },


### PR DESCRIPTION
having html_notes on creates error when the notes happen to contain html tags.